### PR TITLE
fix missing semi-colon

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function attachCamera(canvas, opts) {
 
     if (opts.scale && (mbut.middle || (mbut.left && !ctrl && alt))) {
       var d = mpos.y - mpos.prevY
-      if (!d) return
+      if (!d) return;
 
       camera.distance *= Math.exp(d / height)
     }


### PR DESCRIPTION
Looks like an automated tool went to semi-colon crazy on your code and removed important expression delimiters. This was manifesting as an error in the [webgl-workshop](https://www.npmjs.com/package/webgl-workshop) tutorial:
![screen shot 2015-04-19 at 1 34 39 pm](https://cloud.githubusercontent.com/assets/129330/7220532/eeaa1fd2-e698-11e4-960e-2fbef1fe07ff.png)
